### PR TITLE
Install SetextHeadingProcessor

### DIFF
--- a/pycmark_gfm/__init__.py
+++ b/pycmark_gfm/__init__.py
@@ -27,6 +27,7 @@ from pycmark.blockparser.html_processors import (
 from pycmark.blockparser.std_processors import (
     ThematicBreakProcessor,
     ATXHeadingProcessor,
+    SetextHeadingProcessor,
     IndentedCodeBlockProcessor,
     BlankLineProcessor,
     BacktickFencedCodeBlockProcessor,
@@ -93,6 +94,7 @@ class GFMParser(Parser):
         return [
             ThematicBreakProcessor,
             ATXHeadingProcessor,
+            SetextHeadingProcessor,
             IndentedCodeBlockProcessor,
             BlankLineProcessor,
             BacktickFencedCodeBlockProcessor,


### PR DESCRIPTION
since pycmark-0.9.1, setext heading processing has been moved to SetextHeadingProcessor...