### PR TITLE
Rename GFMParser to Parser

### DIFF
--- a/pycmark_gfm/__init__.py
+++ b/pycmark_gfm/__init__.py
@@ -10,9 +10,9 @@
 
 from typing import List, Type
 
+import pycmark
 from docutils import nodes
 from docutils.transforms import Transform
-from pycmark import CommonMarkParser
 from pycmark.blockparser import BlockProcessor
 from pycmark.blockparser.html_processors import StandardTagsHTMLBlockProcessor
 from pycmark.inlineparser import InlineProcessor
@@ -37,7 +37,7 @@ from pycmark_gfm.transforms import (
 )
 
 
-class GFMParser(CommonMarkParser):
+class Parser(pycmark.Parser):
     """GitHub Flavored Markdown parser for docutils."""
 
     supported = ('markdown', 'md')

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires=">=3.7",
     packages=find_packages(exclude=['tests']),
     install_requires=[
-        'pycmark>=0.9.5',
+        'pycmark>=0.9.6',
     ],
     extras_require={
         'test': [

--- a/spec/gfm2html.py
+++ b/spec/gfm2html.py
@@ -19,7 +19,7 @@ from docutils.writers.html5_polyglot import Writer, HTMLTranslator
 from pycmark.transforms import LinebreakFilter, SectionTreeConstructor
 
 from pycmark_gfm import addnodes
-from pycmark_gfm import GFMParser
+from pycmark_gfm import Parser
 from pycmark_gfm.inlineparser.std_processors import DisallowedRawHTMLProcessor
 from pycmark_gfm.transforms import TaskListItemConverter
 
@@ -212,7 +212,7 @@ class DisabledRawHTMLTransform(Transform):
                 text.parent.replace(text, nodes.raw('', html, format='html'))
 
 
-class TestGFMParser(GFMParser):
+class TestGFMParser(Parser):
     def get_transforms(self):
         transforms = super().get_transforms()
         transforms.remove(LinebreakFilter)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ from docutils.core import publish_doctree
 from docutils.readers.standalone import Reader
 from pycmark.transforms import LinebreakFilter
 
-from pycmark_gfm import GFMParser
+from pycmark_gfm import Parser
 from pycmark_gfm.transforms import TaskListItemConverter
 
 from sphinx import assert_node  # NOQA
@@ -21,7 +21,7 @@ class TestReader(Reader):
         return []  # skip all of transforms!
 
 
-class TestParser(GFMParser):
+class TestParser(Parser):
     def get_transforms(self):
         transforms = super().get_transforms()
         transforms.remove(LinebreakFilter)


### PR DESCRIPTION
Docutils expects a parser class is named as "Parser" when it searches a
parse from 3rd party module.

This follows the expectation by renaming CommonMarkparser class to
"Parser".